### PR TITLE
allow response bodies to be empty

### DIFF
--- a/src/Apiary/ApiaryGenerator.fs
+++ b/src/Apiary/ApiaryGenerator.fs
@@ -57,7 +57,8 @@ module internal ApiaryTypeBuilder =
             match example.TryGetProperty "body" with
             | Some body -> 
                 let source = body.InnerText()
-                yield JsonValue.ParseSample(source)
+                if String.IsNullOrEmpty source then ()
+                else yield JsonValue.ParseSample source
             | None -> () ]
 
     let result =


### PR DESCRIPTION
This makes the Storefront API not error out. #15
